### PR TITLE
Add default fg and bg colors

### DIFF
--- a/ansi.go
+++ b/ansi.go
@@ -272,6 +272,10 @@ const (
 	MagentaBG Attribute = "45"
 	CyanBG    Attribute = "46"
 	WhiteBG   Attribute = "47"
+
+	// Default Colors
+	Default   Attribute = "39"
+	DefaultBG Attribute = "49"
 )
 
 //Set attributes


### PR DESCRIPTION
Default colors returns the default setting of the user's terminal. 
For example if the user's font is set to Red the default Attribute will make the font Red again.